### PR TITLE
fix: correct typos and bugs in documentation and scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help test lint format clean install ci-test all
+.PHONY: help test test-cov lint format format-check type-check clean install ci-test ci-local ci-matrix all pre-commit
 
 # Default target
 help:

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ pipx install --pip-args="--pre" "vllm-cli[vllm]"
 
 ```bash
 # Interactive mode - menu-driven interface
-vllm-cl
+vllm-cli
 # Serve a model
 vllm-cli serve --model openai/gpt-oss-20b
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -5,7 +5,7 @@ Seven carefully designed profiles cover most common use cases and hardware confi
 ## General Purpose Profiles
 
 ### `standard` - Minimal configuration with smart defaults
-Uses vLLM's defaults configuration. Perfect for most models and hardware setups.
+Uses vLLM's default configuration. Perfect for most models and hardware setups.
 
 **Use Case:** Starting point for any model, general inference tasks
 **Configuration:** No additional arguments - uses vLLM defaults
@@ -182,7 +182,7 @@ Common environment variables used in profiles:
 
 | Variable | Purpose | Values |
 |----------|---------|---------|
-| `VLLM_ATTENTION_BACKEND` | Attention computation backend | `FLASH_ATTN`, `XFORMERS`, `TRITON` |
+| `VLLM_ATTENTION_BACKEND` | Attention computation backend | `FLASH_ATTN`, `XFORMERS`, `TRITON_ATTN_VLLM_V1` |
 | `VLLM_USE_TRITON_FLASH_ATTN` | Enable Triton flash attention | `0`, `1` |
 | `VLLM_ENABLE_FUSED_MOE_ACTIVATION_CHUNKING` | MoE activation chunking | `0`, `1` |
 | `VLLM_USE_FLASHINFER_MXFP4_BF16_MOE` | BF16 precision for MoE | `0`, `1` |

--- a/scripts/test_ci_locally.sh
+++ b/scripts/test_ci_locally.sh
@@ -51,8 +51,10 @@ fi
 run_test "Unit Tests" "pytest tests/ -v --tb=short"
 
 # 4. Check Test Coverage (optional but informative)
-if command -v pytest-cov &> /dev/null; then
+if python -c "import pytest_cov" 2>/dev/null; then
     run_test "Test Coverage" "pytest tests/ --cov=src/vllm_cli --cov-report=term-missing --cov-fail-under=50"
+else
+    echo -e "${YELLOW}⚠️  Skipping coverage (pytest-cov not installed)${NC}\n"
 fi
 
 # 5. Linting with flake8
@@ -90,7 +92,16 @@ run_test "CLI Help Test" "python -m vllm_cli --help > /dev/null"
 
 # 12. Validate pyproject.toml
 if [ -f "pyproject.toml" ]; then
-    run_test "Validate pyproject.toml" "python -c 'import toml; toml.load(\"pyproject.toml\"); print(\"pyproject.toml is valid\")'"
+    run_test "Validate pyproject.toml" "python -c '
+try:
+    import tomllib
+    with open(\"pyproject.toml\", \"rb\") as f:
+        tomllib.load(f)
+except ImportError:
+    import toml
+    toml.load(\"pyproject.toml\")
+print(\"pyproject.toml is valid\")
+'"
 fi
 
 # Summary


### PR DESCRIPTION
## Summary

This pull request fixes several typos and bugs found in the documentation and build scripts.

## Changes

### README.md
- **Line 135**: Fixed typo in Basic Usage section where the command `vllm-cl` was missing the trailing `i`. Changed to `vllm-cli`.

### Makefile
- **Line 1**: The `.PHONY` declaration was incomplete. Added missing targets: `test-cov`, `format-check`, `type-check`, `ci-local`, `ci-matrix`, and `pre-commit`. Without proper `.PHONY` declarations, make may skip execution if a file with the same name exists in the directory.

### scripts/test_ci_locally.sh
- **Line 54**: Fixed pytest-cov detection logic. The original code used `command -v pytest-cov` which checks for a shell command, but pytest-cov is a Python package/pytest plugin, not a standalone executable. Changed to use `python -c "import pytest_cov"` for proper detection. Also added a skip message when pytest-cov is not installed.
- **Line 93-104**: Fixed pyproject.toml validation to be compatible with both Python 3.11+ (which has built-in `tomllib`) and earlier Python versions (which require the `toml` package). The original code only used `import toml` which would fail on Python 3.11+ if the `toml` package is not installed.

### docs/profiles.md
- **Line 8**: Fixed grammar error. Changed `Uses vLLM's defaults configuration` to `Uses vLLM's default configuration` (singular form of "default" as adjective).
- **Line 185**: Updated the `VLLM_ATTENTION_BACKEND` environment variable reference table. Changed `TRITON` to `TRITON_ATTN_VLLM_V1` to match the actual value used in the `gpt_oss_ampere` profile (line 71).

## Testing

All changes are documentation and configuration fixes that do not affect runtime behavior. The script fixes improve compatibility across different Python versions and environments.